### PR TITLE
Allow to add options

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,13 +12,13 @@ import { mdx } from "@mdx-js/react"
 // import statements are manually added.
 //
 // This implementation is roughly based on the @mdx-js/mdx: https://github.com/mdx-js/mdx/blob/main/packages/loader/index.js.
-module.exports = {
+module.exports = (options) => ({
 	name: "esbuild-mdx",
 	setup(build) {
 		build.onLoad({ filter: /\.mdx?$/ }, async args => {
 			const text = await fs.promises.readFile(args.path, "utf8")
 
-			let contents = await mdx(text)
+			let contents = await mdx(text, options)
 			contents = missingImportStatements + "\n\n" + contents
 			return {
 				contents,
@@ -26,4 +26,4 @@ module.exports = {
 			}
 		})
 	},
-}
+})

--- a/index.js
+++ b/index.js
@@ -11,8 +11,8 @@ import { mdx } from "@mdx-js/react"
 // These files are then read from disk and parsed by @mdx-js/mdx. Finally,
 // import statements are manually added.
 //
-// This implementation is roughly based on the @mdx-js/mdx: https://github.com/mdx-js/mdx/blob/main/packages/loader/index.js.
-module.exports = (options) => ({
+// This implementation is roughly based on @mdx-js/mdx: https://github.com/mdx-js/mdx/blob/main/packages/loader/index.js.
+module.exports = options => ({
 	name: "esbuild-mdx",
 	setup(build) {
 		build.onLoad({ filter: /\.mdx?$/ }, async args => {


### PR DESCRIPTION
The official webpack MDX plugin allows to pass options (like remark plugins) to the mdx loader. It could be really awesome to allow it in esbuild too.

I'd would have preferred to be able to do `plugins: [require("esbuild-mdx")]` when were are no options and `plugins: [require("esbuild-mdx")(customOptions)]` when you want to set some, but there is no clean way in JS and in ESBuild (that I know of) to create a function/object.

If you agree to merge this PR, we'll have to also change in [esbuild-mdx-example](https://github.com/zaydek/esbuild-mdx-example/blob/master/esbuild.js#L12)'s config to be:
```diff
  require("esbuild")
  	.build({
  		bundle: true,
  		define: {
  			"process.env.NODE_ENV": JSON.stringify(process.env.NODE_ENV || "development"),
  		},
  		entryPoints: ["src/index.js"],
  		loader: {
  			".js": "jsx",
  		},
  		outfile: "build/app.js",
- 		plugins: [require("esbuild-mdx")],
+ 		plugins: [require("esbuild-mdx")()],
  	})
  	.catch(() => process.exit(1))
```